### PR TITLE
Fix: Formato de fecha y mejoras visuales en ReporteScreen

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,7 +4,7 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2025-06-19T20:04:01.397877Z">
+        <DropdownSelection timestamp="2025-06-20T19:47:27.170419500Z">
           <Target type="DEFAULT_BOOT">
             <handle>
               <DeviceId pluginId="PhysicalDevice" identifier="serial=8903ceb80408" />

--- a/app/src/main/java/pe/cibertec/gestorgo/MainActivity.kt
+++ b/app/src/main/java/pe/cibertec/gestorgo/MainActivity.kt
@@ -7,8 +7,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import dagger.hilt.android.AndroidEntryPoint
 import io.github.jan.supabase.SupabaseClient
-import io.github.jan.supabase.auth.auth
-import kotlinx.serialization.json.jsonPrimitive
 import pe.cibertec.gestorgo.navigation.NavigationScreen
 import pe.cibertec.gestorgo.ui.theme.GestorGoTheme
 import javax.inject.Inject

--- a/app/src/main/java/pe/cibertec/gestorgo/core/Fecha.kt
+++ b/app/src/main/java/pe/cibertec/gestorgo/core/Fecha.kt
@@ -1,4 +1,5 @@
 import java.time.OffsetDateTime
+import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.util.Locale
 
@@ -6,9 +7,11 @@ object Fecha {
     fun formatearFecha(fechaString: String?): String {
         if (fechaString.isNullOrBlank()) return "Fecha no disponible"
         return try {
-            val dateTime = OffsetDateTime.parse(fechaString, DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+            val zonaLima = ZoneId.of("America/Lima")
+            val dateTime = OffsetDateTime.parse(fechaString)
+            val dateTimeLima = dateTime.atZoneSameInstant(zonaLima)
             val outputFormatter = DateTimeFormatter.ofPattern("dd 'de' MMMM 'de' yyyy, hh:mm a", Locale("es"))
-            dateTime.format(outputFormatter)
+            dateTimeLima.format(outputFormatter)
         } catch (e: Exception) {
             "Formato inválido: ${e.message}"
         }

--- a/app/src/main/java/pe/cibertec/gestorgo/features/inventario/ui/reporte/ReporteScreen.kt
+++ b/app/src/main/java/pe/cibertec/gestorgo/features/inventario/ui/reporte/ReporteScreen.kt
@@ -67,8 +67,8 @@ fun ReporteScreen(
     val bars = listaItems.map {
         Bar(
             label = it.nombre,
-            value = it.cantidad?.toFloat() ?: 0f,
-            color = MaterialTheme.colorScheme.primary
+            value = (it.cantidad ?: 0).toFloat().toInt().toFloat(),
+            color = MaterialTheme.colorScheme.primaryContainer
         )
     }
 
@@ -115,7 +115,7 @@ fun ReporteScreen(
                 }
             }
         ) {
-            Text("Exportar CSV 📥", style = MaterialTheme.typography.bodySmall)
+            Text("Exportar en Excel 📥", style = MaterialTheme.typography.bodySmall)
         }
     }
 }
@@ -133,7 +133,8 @@ fun InventoryBarChart(barChartData: BarChartData) {
         BarChart(
             barChartData = barChartData,
             modifier = Modifier
-                .width(totalWidth)
+                .width(totalWidth + 40.dp) // añade espacio a izquierda/derecha
+                .padding(start = 20.dp, end = 20.dp)
                 .height(400.dp),
             animation = simpleChartAnimation(),
             barDrawer = SimpleBarDrawer(),


### PR DESCRIPTION
- Se corrige el formateo de fecha para mostrarla en la zona horaria de Lima (America/Lima).
- En `ReporteScreen`:
    - Se ajusta el color de las barras del gráfico a `primaryContainer`.
    - Se modifica el texto del botón de exportación a "Exportar en Excel 📥".
    - Se aumenta el ancho del `BarChart` y se añade padding horizontal para mejorar la visualización.
    - Se eliminan importaciones no utilizadas en `MainActivity.kt`.